### PR TITLE
Fix for: #14 `GLIBCXX_3.4.21' not found (required log-plugin.so) / Updated `samp-log-core` to 0.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ if (MSVC)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 elseif(UNIX)
 	# hide non-exported symbols
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++98 -pedantic -fvisibility=hidden")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu89 -pedantic -fvisibility=hidden")
 	set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS OFF)
 
 	# link runtime statically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
+cmake_policy(SET CMP0091 NEW)
 project(log-plugin VERSION 0.4)
 
 if (NOT LOG_PLUGIN_VERSION) # allow version override
@@ -7,11 +8,25 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/libs/cmake")
 
-if(UNIX)
-	# force 32bit compilation and hide non-exported symbols
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -fvisibility=hidden")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32 -fvisibility=hidden")
+# build static libraries
+set(BUILD_SHARED_LIBS OFF)
+
+if (MSVC)
+	add_link_options(/INCREMENTAL:NO /NODEFAULTLIB:MSVCRT)
+	# link runtime statically
+	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+elseif(UNIX)
+	# hide non-exported symbols
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
 	set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS OFF)
+
+	# link runtime statically
+	# set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+	add_link_options(
+		"-static-libgcc"
+		"-static-libstdc++"
+	)
 endif()
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: '{branch}-{build}'
 
 image:
-  - Ubuntu1804
   - Visual Studio 2019
+  - Ubuntu1804
 
 environment:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: '{branch}-{build}'
 
 image:
-  - Ubuntu1604
-  - Visual Studio 2017
+  - Ubuntu1804
+  - Visual Studio 2019
 
 environment:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
   global:
     CMAKE_BUILD_PARALLEL_LEVEL: 2
   matrix:
-    - BUILD_TYPE: Debug
     - BUILD_TYPE: Release
+    - BUILD_TYPE: Debug
 
 install:
   # set version environment variable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,12 +31,12 @@ install:
 before_build:
   # set up log-core
   # Windows
-  - cmd: appveyor DownloadFile "https://github.com/maddinat0r/samp-log-core/releases/download/v0.5/samp-log-core-v0.5-win32.zip" -FileName samp-log-core.zip
+  - cmd: appveyor DownloadFile "https://github.com/maddinat0r/samp-log-core/releases/download/v0.5.2/samp-log-core-v0.5.2-win32.zip" -FileName samp-log-core.zip
   - cmd: 7z x samp-log-core.zip -y
   - cmd: move samp-log-core-* "C:\samp-log-core"
   - cmd: set LOGCORE_DIR="C:\samp-log-core\cmake"
   # Linux
-  - sh: wget -q "https://github.com/maddinat0r/samp-log-core/releases/download/v0.5/samp-log-core-v0.5-Linux.tar.gz" -O samp-log-core.tar.gz
+  - sh: wget -q "https://github.com/maddinat0r/samp-log-core/releases/download/v0.5.2/samp-log-core-v0.5.2-Linux.tar.gz" -O samp-log-core.tar.gz
   - sh: mkdir -p samp-log-core && tar zfx samp-log-core.tar.gz -C samp-log-core --strip-components=1
   - sh: export LOGCORE_DIR="samp-log-core/cmake"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,13 @@ install:
   - sh: sudo apt-get -qq update
   - sh: sudo apt-get -qq -y install g++-multilib gcc-multilib
   - sh: "echo g++ version: $(g++ --version | cut -d$'\n' -f1)"
+  # set CMake platform arg on MSVC
+  - ps: |
+      if ($isWindows) { 
+        $CMAKE_ARGS = "-AWin32", "-Thost=x86"
+      } else {
+        $CMAKE_ARGS = "-DCMAKE_CXX_FLAGS=-m32", "-DCMAKE_C_FLAGS=-m32"
+      }
 
 before_build:
   # set up log-core
@@ -34,7 +41,7 @@ before_build:
   - sh: export LOGCORE_DIR="samp-log-core/cmake"
 
 build_script:
-  - ps: cmake -Wno-dev -Dlog-core_DIR="$env:LOGCORE_DIR" -DLOG_PLUGIN_VERSION="$env:GIT_REPO_VERSION" -DCMAKE_BUILD_TYPE="$env:BUILD_TYPE" -S . -B build
+  - ps: cmake -Wno-dev -Dlog-core_DIR="$env:LOGCORE_DIR" -DLOG_PLUGIN_VERSION="$env:GIT_REPO_VERSION" -DCMAKE_BUILD_TYPE="$env:BUILD_TYPE" @CMAKE_ARGS -S . -B build
   - ps: cmake --build build --config $env:BUILD_TYPE --target package
 
 artifacts:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,6 @@ elseif(UNIX)
 		-Wall
 		-Wextra
 		-pedantic
-		-Werror
 	)
 endif()
 


### PR DESCRIPTION
Original PR text:
> This PR is partial fix for issue #14.
> But issue with `GLIBCXX_3.4.21` still occurs with `samp-log-core` itself, because `samp-log` uses outdated version of `samp-log-core` (without statically linked `libgcc` & `libstdc++`) - to fix it, we need to update `samp-log` to use latest version of `samp-log-core`.

**Updated PR description:**
This PR fixes error `'GLIBCXX_3.4.21' not found` (closes #14)
- [x] Actualized `CMakeLists.txt`
- [x] Actualized ` appveyor.yml`
└ Now, these files almost the same as `samp-log-core`'s files
- [x] Bumped to `samp-log-core v0.5.2`
- [x] Pinned C++ & C std's to be `-std=gnu++98` &  `-std=gnu89`, but:

Maybe, we no need to do pinning to specific std's versions, ! but exactly these versions were used at officially supported by SAMP `gcc 4.9.2` - `libstdc++ 6.0.20`.
(it took me a long time to figure it out by googling the gcc documentation, changelogs & migration guides).